### PR TITLE
Improve Baileys disconnect diagnostics and reconnect backoff

### DIFF
--- a/src/services/WhatsAppService.js
+++ b/src/services/WhatsAppService.js
@@ -15,6 +15,7 @@ class WhatsAppService {
     constructor(io) {
         this.io = io;
         this.sessions = new Map(); // userId => session object
+        this.reconnectAttempts = new Map(); // userId => retry count
         this.appSettings = {};
         this.autoReplies = [];
         this.webhookService = null;
@@ -140,6 +141,7 @@ class WhatsAppService {
             session.isConnected = true;
             session.state = 'connected';
             session.qr = null;
+            this.reconnectAttempts.set(userId, 0);
             this.io.to(userId).emit('connection_status', { status: 'connected' });
             console.log(`WhatsApp connected for user: ${userId}`);
             if (this.webhookService && this.appSettings.webhook_toggle_connection !== 'false') {
@@ -160,8 +162,12 @@ class WhatsAppService {
             }
             this.sessions.delete(userId);
 
-            const code = lastDisconnect?.error?.output?.statusCode;
+            const code = lastDisconnect?.error?.output?.statusCode ||
+                         lastDisconnect?.error?.statusCode ||
+                         lastDisconnect?.error?.data;
             const loggedOut = code === DisconnectReason.loggedOut;
+            const disconnectMessage = this.getDisconnectMessage(lastDisconnect?.error);
+            console.warn(`WhatsApp disconnected for user ${userId}. Code: ${code || 'unknown'}. Reason: ${disconnectMessage}`);
             
             if (loggedOut) {
                 try {
@@ -175,11 +181,27 @@ class WhatsAppService {
 
             // Reconnect after delay unless user intentionally logged out
             if (!loggedOut) {
-                setTimeout(() => this.createSession(userId), 1000);
+                const retryCount = (this.reconnectAttempts.get(userId) || 0) + 1;
+                this.reconnectAttempts.set(userId, retryCount);
+                const reconnectDelay = Math.min(1000 * (2 ** Math.min(retryCount - 1, 4)), 30000);
+                console.log(`Scheduling reconnect for user ${userId} in ${reconnectDelay}ms (attempt ${retryCount})`);
+                setTimeout(() => this.createSession(userId), reconnectDelay);
             } else {
+                this.reconnectAttempts.delete(userId);
                 console.log('Intentional logout detected; skipping auto-reconnect.');
             }
         }
+    }
+
+    /**
+     * Extract readable disconnect reason from Baileys error object
+     */
+    getDisconnectMessage(error) {
+        if (!error) return 'Unknown disconnect reason';
+        if (typeof error === 'string') return error;
+        if (error?.message) return error.message;
+        if (error?.data) return String(error.data);
+        return 'Unknown disconnect reason';
     }
 
     /**
@@ -465,6 +487,7 @@ class WhatsAppService {
             clearInterval(session.keepAliveTimer);
         }
         this.sessions.delete(userIdStr);
+        this.reconnectAttempts.delete(userIdStr);
 
         const authDir = join(__dirname, '../../auth_info_baileys', userIdStr);
         try {

--- a/src/services/WhatsAppService.js
+++ b/src/services/WhatsAppService.js
@@ -15,7 +15,9 @@ class WhatsAppService {
     constructor(io) {
         this.io = io;
         this.sessions = new Map(); // userId => session object
+        this.pendingSessionPromises = new Map(); // userId => in-flight session creation promise
         this.reconnectAttempts = new Map(); // userId => retry count
+        this.reconnectTimers = new Map(); // userId => scheduled reconnect timer
         this.appSettings = {};
         this.autoReplies = [];
         this.webhookService = null;
@@ -57,6 +59,10 @@ class WhatsAppService {
             return this.sessions.get(userIdStr);
         }
 
+        if (this.pendingSessionPromises.has(userIdStr)) {
+            return await this.pendingSessionPromises.get(userIdStr);
+        }
+
         return await this.createSession(userIdStr, phoneNumber);
     }
 
@@ -65,30 +71,54 @@ class WhatsAppService {
      */
     async createSession(userId, phoneNumber = null) {
         const userIdStr = String(userId);
-        const authDir = join(__dirname, '../../auth_info_baileys', userIdStr);
-        const { state, saveCreds } = await useMultiFileAuthState(authDir);
 
-        const session = {
-            sock: null,
-            isConnected: false,
-            state: 'disconnected',
-            qr: null,
-            keepAliveTimer: null
-        };
+        if (this.sessions.has(userIdStr)) {
+            return this.sessions.get(userIdStr);
+        }
 
-        const sock = makeWASocket({
-            auth: state,
-            printQRInTerminal: false,
-            browser: ['WhatsApp API', 'Chrome', '1.0.0'],
-            keepAliveIntervalMs: config.whatsapp.keepAliveIntervalMs,
-            markOnlineOnConnect: config.whatsapp.markOnlineOnConnect
-        });
+        if (this.pendingSessionPromises.has(userIdStr)) {
+            return await this.pendingSessionPromises.get(userIdStr);
+        }
 
-        session.sock = sock;
-        this.setupSessionHandlers(session, userIdStr, saveCreds, authDir);
-        this.sessions.set(userIdStr, session);
+        if (this.reconnectTimers.has(userIdStr)) {
+            clearTimeout(this.reconnectTimers.get(userIdStr));
+            this.reconnectTimers.delete(userIdStr);
+        }
 
-        return session;
+        const createPromise = (async () => {
+            const authDir = join(__dirname, '../../auth_info_baileys', userIdStr);
+            const { state, saveCreds } = await useMultiFileAuthState(authDir);
+
+            const session = {
+                sock: null,
+                isConnected: false,
+                state: 'disconnected',
+                qr: null,
+                keepAliveTimer: null,
+                intentionalLogout: false
+            };
+
+            const sock = makeWASocket({
+                auth: state,
+                printQRInTerminal: false,
+                browser: ['WhatsApp API', 'Chrome', '1.0.0'],
+                keepAliveIntervalMs: config.whatsapp.keepAliveIntervalMs,
+                markOnlineOnConnect: config.whatsapp.markOnlineOnConnect
+            });
+
+            session.sock = sock;
+            this.setupSessionHandlers(session, userIdStr, saveCreds, authDir);
+            this.sessions.set(userIdStr, session);
+
+            return session;
+        })();
+
+        this.pendingSessionPromises.set(userIdStr, createPromise);
+        try {
+            return await createPromise;
+        } finally {
+            this.pendingSessionPromises.delete(userIdStr);
+        }
     }
 
     /**
@@ -165,7 +195,7 @@ class WhatsAppService {
             const code = lastDisconnect?.error?.output?.statusCode ||
                          lastDisconnect?.error?.statusCode ||
                          lastDisconnect?.error?.data;
-            const loggedOut = code === DisconnectReason.loggedOut;
+            const loggedOut = code === DisconnectReason.loggedOut || session.intentionalLogout;
             const disconnectMessage = this.getDisconnectMessage(lastDisconnect?.error);
             console.warn(`WhatsApp disconnected for user ${userId}. Code: ${code || 'unknown'}. Reason: ${disconnectMessage}`);
             
@@ -185,9 +215,20 @@ class WhatsAppService {
                 this.reconnectAttempts.set(userId, retryCount);
                 const reconnectDelay = Math.min(1000 * (2 ** Math.min(retryCount - 1, 4)), 30000);
                 console.log(`Scheduling reconnect for user ${userId} in ${reconnectDelay}ms (attempt ${retryCount})`);
-                setTimeout(() => this.createSession(userId), reconnectDelay);
+                if (this.reconnectTimers.has(userId)) {
+                    clearTimeout(this.reconnectTimers.get(userId));
+                }
+                const reconnectTimer = setTimeout(() => {
+                    this.reconnectTimers.delete(userId);
+                    this.createSession(userId);
+                }, reconnectDelay);
+                this.reconnectTimers.set(userId, reconnectTimer);
             } else {
                 this.reconnectAttempts.delete(userId);
+                if (this.reconnectTimers.has(userId)) {
+                    clearTimeout(this.reconnectTimers.get(userId));
+                    this.reconnectTimers.delete(userId);
+                }
                 console.log('Intentional logout detected; skipping auto-reconnect.');
             }
         }
@@ -477,6 +518,8 @@ class WhatsAppService {
         const session = this.sessions.get(userIdStr);
         if (!session) return;
 
+        session.intentionalLogout = true;
+
         try {
             await session.sock.logout();
         } catch (error) {
@@ -487,7 +530,12 @@ class WhatsAppService {
             clearInterval(session.keepAliveTimer);
         }
         this.sessions.delete(userIdStr);
+        this.pendingSessionPromises.delete(userIdStr);
         this.reconnectAttempts.delete(userIdStr);
+        if (this.reconnectTimers.has(userIdStr)) {
+            clearTimeout(this.reconnectTimers.get(userIdStr));
+            this.reconnectTimers.delete(userIdStr);
+        }
 
         const authDir = join(__dirname, '../../auth_info_baileys', userIdStr);
         try {

--- a/src/services/WhatsAppService.js
+++ b/src/services/WhatsAppService.js
@@ -18,6 +18,7 @@ class WhatsAppService {
         this.pendingSessionPromises = new Map(); // userId => in-flight session creation promise
         this.reconnectAttempts = new Map(); // userId => retry count
         this.reconnectTimers = new Map(); // userId => scheduled reconnect timer
+        this.lastDisconnectReasons = new Map(); // userId => last readable disconnect reason
         this.appSettings = {};
         this.autoReplies = [];
         this.webhookService = null;
@@ -172,6 +173,7 @@ class WhatsAppService {
             session.state = 'connected';
             session.qr = null;
             this.reconnectAttempts.set(userId, 0);
+            this.lastDisconnectReasons.delete(userId);
             this.io.to(userId).emit('connection_status', { status: 'connected' });
             console.log(`WhatsApp connected for user: ${userId}`);
             if (this.webhookService && this.appSettings.webhook_toggle_connection !== 'false') {
@@ -197,7 +199,13 @@ class WhatsAppService {
                          lastDisconnect?.error?.data;
             const loggedOut = code === DisconnectReason.loggedOut || session.intentionalLogout;
             const disconnectMessage = this.getDisconnectMessage(lastDisconnect?.error);
+            const networkIssue = this.isNetworkDisconnect(code, disconnectMessage);
+            this.lastDisconnectReasons.set(userId, disconnectMessage);
             console.warn(`WhatsApp disconnected for user ${userId}. Code: ${code || 'unknown'}. Reason: ${disconnectMessage}`);
+            if (networkIssue) {
+                session.state = 'network_error';
+                this.io.to(userId).emit('connection_status', { status: 'network_error', reason: disconnectMessage });
+            }
             
             if (loggedOut) {
                 try {
@@ -213,7 +221,9 @@ class WhatsAppService {
             if (!loggedOut) {
                 const retryCount = (this.reconnectAttempts.get(userId) || 0) + 1;
                 this.reconnectAttempts.set(userId, retryCount);
-                const reconnectDelay = Math.min(1000 * (2 ** Math.min(retryCount - 1, 4)), 30000);
+                const reconnectDelay = networkIssue
+                    ? Math.min(10000 * retryCount, 60000)
+                    : Math.min(1000 * (2 ** Math.min(retryCount - 1, 4)), 30000);
                 console.log(`Scheduling reconnect for user ${userId} in ${reconnectDelay}ms (attempt ${retryCount})`);
                 if (this.reconnectTimers.has(userId)) {
                     clearTimeout(this.reconnectTimers.get(userId));
@@ -232,6 +242,19 @@ class WhatsAppService {
                 console.log('Intentional logout detected; skipping auto-reconnect.');
             }
         }
+    }
+
+    /**
+     * Detect transient network / DNS related disconnects
+     */
+    isNetworkDisconnect(code, reason = '') {
+        const text = String(reason || '').toUpperCase();
+        return code === DisconnectReason.connectionLost ||
+               code === DisconnectReason.connectionClosed ||
+               text.includes('EAI_AGAIN') ||
+               text.includes('ENOTFOUND') ||
+               text.includes('ECONNRESET') ||
+               text.includes('ETIMEDOUT');
     }
 
     /**
@@ -532,6 +555,7 @@ class WhatsAppService {
         this.sessions.delete(userIdStr);
         this.pendingSessionPromises.delete(userIdStr);
         this.reconnectAttempts.delete(userIdStr);
+        this.lastDisconnectReasons.delete(userIdStr);
         if (this.reconnectTimers.has(userIdStr)) {
             clearTimeout(this.reconnectTimers.get(userIdStr));
             this.reconnectTimers.delete(userIdStr);
@@ -553,13 +577,19 @@ class WhatsAppService {
     getSessionStatus(userId) {
         const session = this.sessions.get(String(userId));
         if (!session) {
-            return { status: 'disconnected', connected: false, qr: null };
+            return {
+                status: 'disconnected',
+                connected: false,
+                qr: null,
+                reason: this.lastDisconnectReasons.get(String(userId)) || null
+            };
         }
         
         return {
             status: session.state,
             connected: session.isConnected,
-            qr: session.qr
+            qr: session.qr,
+            reason: this.lastDisconnectReasons.get(String(userId)) || null
         };
     }
 

--- a/src/services/WhatsAppService.js
+++ b/src/services/WhatsAppService.js
@@ -254,7 +254,10 @@ class WhatsAppService {
                text.includes('EAI_AGAIN') ||
                text.includes('ENOTFOUND') ||
                text.includes('ECONNRESET') ||
-               text.includes('ETIMEDOUT');
+               text.includes('ETIMEDOUT') ||
+               text.includes('GETADDRINFO') ||
+               text.includes('WEBSOCKET ERROR') ||
+               text.includes('CONNECTION FAILURE');
     }
 
     /**

--- a/views/partials/scripts.ejs
+++ b/views/partials/scripts.ejs
@@ -182,7 +182,7 @@
 
     socket.on('connection_status', (data) => {
         console.log('Connection status:', data);
-        updateStatus(data.status);
+        updateStatus(data.status, data.reason);
     });
 
     socket.on('new_message', (message) => {
@@ -264,7 +264,7 @@
         }
     }
 
-    function updateStatus(status) {
+    function updateStatus(status, reason = null) {
         currentStatus = status;
 
         // Update status indicator and icon
@@ -296,11 +296,25 @@
                     testBtn.disabled = true;
                     waLogoutBtn.disabled = true;
                     break;
+                case 'network_error':
+                    statusElement.textContent = 'Gangguan Jaringan';
+                    statusElement.className = 'text-xl font-bold text-amber-600';
+                    statusMessageElement.textContent = reason
+                        ? `Koneksi ke WhatsApp terganggu: ${reason}`
+                        : 'Koneksi ke WhatsApp terganggu (DNS / internet VPS).';
+                    statusIndicator.className = 'w-2.5 h-2.5 rounded-full bg-amber-500 status-pulse';
+                    statusIcon.className = 'ri-wifi-off-line text-amber-600 text-xl';
+                    connectionCard.style.display = 'none';
+                    testBtn.disabled = true;
+                    waLogoutBtn.disabled = true;
+                    break;
                 case 'disconnected':
                 default:
                     statusElement.textContent = 'Terputus';
                     statusElement.className = 'text-xl font-bold text-red-600';
-                    statusMessageElement.textContent = 'WhatsApp belum terhubung.';
+                    statusMessageElement.textContent = reason
+                        ? `WhatsApp belum terhubung. Alasan terakhir: ${reason}`
+                        : 'WhatsApp belum terhubung.';
                     statusIndicator.className = 'w-2.5 h-2.5 rounded-full bg-red-500';
                     statusIcon.className = 'ri-close-circle-line text-red-600 text-xl';
                     connectionCard.style.display = 'none';
@@ -395,7 +409,7 @@
             const response = await fetch('/status');
             const data = await response.json();
 
-            updateStatus(data.status);
+            updateStatus(data.status, data.reason);
 
             if (data.qr) {
                 displayQR(data.qr);


### PR DESCRIPTION
### Motivation
- Connection failures from Baileys were noisy and lacked clear reasons, making troubleshooting hard. 
- The service retried immediately with a fixed 1s delay which can worsen instability on flakey networks. 
- Need better logging and a safer reconnect strategy to reduce log noise and avoid tight retry loops.

### Description
- Modified `src/services/WhatsAppService.js` to add a per-user `reconnectAttempts` map to track retry counts. 
- Reset retry counter when connection opens and clear it on intentional logout to avoid stale state. 
- Improve extraction of disconnect code and add `getDisconnectMessage` to produce a human-readable reason from Baileys error objects and log a warning with code and reason. 
- Replace the fixed 1s reconnect with an exponential backoff (1s, 2s, 4s, ... capped at 30s) and log scheduled reconnect attempts.

### Testing
- Ran `node --check src/services/WhatsAppService.js` which passed successfully. 
- Ran `npm test -- --runInBand` which failed due to existing repository Jest/ESM configuration (`Cannot use import statement outside a module`) and is unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e91e4b0e0832aa03b3ee8c869a30f)